### PR TITLE
fix: update version to 1.0.0-alpha.2 and adjust release workflow comm…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         if: needs.check-version-change.outputs.is_prerelease == 'false'
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-        run: poetry publish --no-build
+        run: poetry publish
 
       
       - name: Publish to Test PyPI
@@ -155,4 +155,4 @@ jobs:
         env:
           POETRY_REPOSITORIES_TESTPYPI_URL: https://test.pypi.org/legacy/
           POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_TOKEN }}
-        run: poetry publish --no-build -r testpypi
+        run: poetry publish -r testpypi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "midi-diff"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "Output the differences between two MIDI files, using the command-line."
 authors = ["Taylor-Jayde Blackstone <t.blackstone@inspyre.tech>"]
 license = "MIT"


### PR DESCRIPTION
This pull request updates the package version and modifies the release workflow to ensure proper package building before publishing. The most important changes are:

Version update:

* Bumped the package version in `pyproject.toml` from `1.0.0-alpha.1` to `1.0.0-alpha.2` to reflect a new release.

Release workflow improvements:

* Updated the `release.yml` workflow to remove the `--no-build` flag from the `poetry publish` commands, ensuring that the package is built before publishing to both PyPI and Test PyPI.

## Summary by Sourcery

Update package version and adjust the release workflow to build artifacts before publishing to PyPI and Test PyPI.

Build:
- Remove the no-build flag from Poetry publish steps so releases to PyPI and Test PyPI build the package before upload.

Chores:
- Bump the project version to 1.0.0-alpha.2 in pyproject configuration.